### PR TITLE
chore: remove registerCommand() in Core and CoreServer

### DIFF
--- a/src/main/java/minevalley/core/api/Core.java
+++ b/src/main/java/minevalley/core/api/Core.java
@@ -193,10 +193,6 @@ public final class Core {
         return server.getUniqueId(name);
     }
 
-    public static void registerCommand(PlayerCommand command) {
-        server.registerCommand(command);
-    }
-
     /**
      * Sends a message to all online team-members
      *

--- a/src/main/java/minevalley/core/api/CoreServer.java
+++ b/src/main/java/minevalley/core/api/CoreServer.java
@@ -98,8 +98,6 @@ public interface CoreServer {
 
     OnlineUser getOnlineUser(Player player);
 
-    void registerCommand(PlayerCommand command);
-
     void sendTeamChatMessage(String message);
 
     void sendTeamChatMessage(BaseComponent[] message);


### PR DESCRIPTION
This method lost its purpose due to the automatic registration of commands